### PR TITLE
:sparkles: Cluster webhook added

### DIFF
--- a/api/v1alpha1/yandexcluster_webhook.go
+++ b/api/v1alpha1/yandexcluster_webhook.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"net"
+	"net/netip"
+	"reflect"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AddrType is a address type
+type AddrType int
+
+// Possible address types
+const (
+	Unknown AddrType = iota + 1
+	FQDN
+	IPV4
+	IPV6
+)
+
+// log is for logging in this package.
+var yandexclusterlog = logf.Log.WithName("yandexcluster-resource")
+
+// SetupWebhookWithManager creates a validation webhook
+func (c *YandexCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(c).
+		Complete()
+}
+
+//nolint:lll // controller-gen marker
+//+kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-yandexcluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=yandexclusters,versions=v1alpha1,name=validation.yandexclusters.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1beta1
+
+var (
+	_ webhook.Defaulter = &YandexCluster{}
+	_ webhook.Validator = &YandexCluster{}
+)
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (c *YandexCluster) Default() {
+	yandexclusterlog.Info("default", "name", c.Name)
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (c *YandexCluster) ValidateCreate() (admission.Warnings, error) {
+	yandexclusterlog.Info("validate create", "name", c.Name)
+	var allErrs field.ErrorList
+
+	if c.Spec.LoadBalancer.Type == LoadBalancerTypeNLB {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "loadBalancer", "type"),
+				c.Spec.LoadBalancer.Type, "network load balancer support will be added in future releases, use application load balancer instead"),
+		)
+	}
+
+	if c.Spec.LoadBalancer.Listener.Address != "" && !isIPv4(c.Spec.LoadBalancer.Listener.Address) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "loadBalancer", "listener", "address"),
+				c.Spec.LoadBalancer.Listener.Address, "field must be a valid IPv4 address"),
+		)
+	}
+
+	if !reflect.DeepEqual(c.Spec.ControlPlaneEndpoint, clusterv1.APIEndpoint{}) {
+		allErrs = append(allErrs, isControlPlaneEndpointValid(c.Spec.ControlPlaneEndpoint)...)
+	}
+
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("YandexCluster").GroupKind(), c.Name, allErrs)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (c *YandexCluster) ValidateUpdate(oldRaw runtime.Object) (admission.Warnings, error) {
+	yandexclusterlog.Info("validate update", "name", c.Name)
+	var allErrs field.ErrorList
+	old, ok := oldRaw.(*YandexCluster)
+	if !ok {
+		return nil, apierrors.NewBadRequest("failed to convert runtime Object to YandexCluster")
+	}
+
+	if !reflect.DeepEqual(old.Spec.LoadBalancer, c.Spec.LoadBalancer) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "loadBalancer"), c.Spec.LoadBalancer, "field is immutable"),
+		)
+	}
+
+	// We allow you to change the ControlPlaneEndpoint only if this field has not been set before.
+	// In all other cases, this field is immutable.
+	if !reflect.DeepEqual(c.Spec.ControlPlaneEndpoint, old.Spec.ControlPlaneEndpoint) {
+		if reflect.DeepEqual(old.Spec.ControlPlaneEndpoint, clusterv1.APIEndpoint{}) {
+			allErrs = append(allErrs, isControlPlaneEndpointValid(c.Spec.ControlPlaneEndpoint)...)
+		} else {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "controlPlaneEndpoint"), c.Spec.ControlPlaneEndpoint, "field is immutable"),
+			)
+		}
+	}
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind("YandexCluster").GroupKind(), c.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (c *YandexCluster) ValidateDelete() (admission.Warnings, error) {
+	yandexclusterlog.Info("validate delete", "name", c.Name)
+	return nil, nil
+}
+
+// getAddrType returns type of address
+func getAddrType(s string) AddrType {
+	parsedIP, err := netip.ParseAddr(s)
+	if err != nil {
+		if _, errfqdn := net.LookupHost(s); errfqdn == nil {
+			return FQDN
+		}
+		return Unknown
+
+	}
+	if parsedIP.Is4() {
+		return IPV4
+	}
+	if parsedIP.Is6() {
+		return IPV6
+	}
+	return Unknown
+}
+
+// isIPv4 checks if address is an ipv4 address
+func isIPv4(s string) bool {
+	return getAddrType(s) == IPV4
+}
+
+// isIPv4orFQDN checks if address is an ipv4 address or FQDN
+func isIPv4orFQDN(s string) bool {
+	result := getAddrType(s)
+	return result == IPV4 || result == FQDN
+}
+
+// isControlPlaneEndpointValid checks if ControlPlaneEndpoint has valid fields
+func isControlPlaneEndpointValid(cp clusterv1.APIEndpoint) field.ErrorList {
+	var errs field.ErrorList
+	if cp.Host == "" || cp.Port == 0 {
+		errs = append(errs,
+			field.Invalid(field.NewPath("spec", "controlPlaneEndpoint"),
+				cp.Port, "fields have to be not empty"),
+		)
+	}
+	if !isIPv4orFQDN(cp.Host) {
+		errs = append(errs,
+			field.Invalid(field.NewPath("spec", "controlPlaneEndpoint", "host"),
+				cp.Host, "field has to be IPv4 or FQDN"),
+		)
+	}
+
+	if cp.Port < 1 || cp.Port > 65535 {
+		errs = append(errs,
+			field.Invalid(field.NewPath("spec", "controlPlaneEndpoint", "port"),
+				cp.Port, "field has to be a network port from range 1-65535"),
+		)
+	}
+	return errs
+}

--- a/api/v1alpha1/yandexcluster_webhook_test.go
+++ b/api/v1alpha1/yandexcluster_webhook_test.go
@@ -1,0 +1,570 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	infrav1 "github.com/yandex-cloud/cluster-api-provider-yandex/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestYandexCluster_ValidateCreate(t *testing.T) {
+	y := NewWithT(t)
+	tests := []struct {
+		name string
+		*infrav1.YandexCluster
+		wantErr bool
+	}{
+		{
+			name: "YandexCluster with FQDN - valid",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster with IPv4 - valid",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "10.10.10.10",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster with incorrect port",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "10.10.10.10",
+						Port: 844355,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect IPv4 endpoint",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "1000.10.10.10",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect FQDN endpoint - 1",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "yaru",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect FQDN endpoint - 2",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "yaru.",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		{
+			name: "YandexCluster with incorrect IPv6 - 1",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "2a02:6b8:a::a",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect IPv6 - 2",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "2a02:06b8:000a:0000:0000:0000:0000:000a",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with empty host endpoint",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "",
+						Port: 8443,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with empty port endpoint",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 0,
+					},
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with application load balancer",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeALB,
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster with network load balancer",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeNLB,
+						Listener: infrav1.ListenerSpec{
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with correct IP address in loadbalancer listener spec",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeALB,
+						Listener: infrav1.ListenerSpec{
+							Address: "1.1.1.1",
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster with incorrect IPv6 address in loadbalancer listener spec",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeALB,
+						Listener: infrav1.ListenerSpec{
+							Address: "2a02:6b8:a::a",
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect IP address in loadbalancer listener spec",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeALB,
+						Listener: infrav1.ListenerSpec{
+							Address: "1.1.1",
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with incorrect fqdn in loadbalancer listener spec",
+			YandexCluster: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Type: infrav1.LoadBalancerTypeALB,
+						Listener: infrav1.ListenerSpec{
+							Address: "ya.ru",
+							Subnet: infrav1.SubnetSpec{
+								ZoneID: "ru-central1-a",
+								ID:     "some-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(_ *testing.T) {
+			warn, err := test.YandexCluster.ValidateCreate()
+			if test.wantErr {
+				y.Expect(err).To(HaveOccurred())
+			} else {
+				y.Expect(err).NotTo(HaveOccurred())
+			}
+			y.Expect(warn).To(BeNil())
+		})
+	}
+}
+
+func TestYandexCluster_ValidateUpdate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name        string
+		newTemplate *infrav1.YandexCluster
+		oldTemplate *infrav1.YandexCluster
+		wantErr     bool
+	}{
+		{
+			name: "YandexCluster with no changes in immutable fields",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 8443,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster with changes in immutable field loadBalancer.name",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Name: "new-name",
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Name: "old-name",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with changes in immutable field loadBalancer.listener",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Internal: false,
+						},
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Listener: infrav1.ListenerSpec{
+							Internal: true,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with changes in immutable field loadBalancer.healthcheck",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Healthcheck: infrav1.HealtcheckSpec{
+							HealthcheckThreshold: 1,
+						},
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					LoadBalancer: infrav1.LoadBalancerSpec{
+						Healthcheck: infrav1.HealtcheckSpec{
+							HealthcheckThreshold: 3,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with changes in empty field controlPlaneEndpoint",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "YandexCluster change empty host to incorrect IPv4",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "1000.10.10.10",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster change empty host to incorrect IPv6",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "2a02:6b8:a::a",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster change empty host to incorrect FQDN",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "yaru",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster change empty host to incorrect port",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 844355,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with changes in non empty field controlPlaneEndpoint",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "ya.ru",
+						Port: 8443,
+					},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "yandex.com",
+						Port: 8444,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "YandexCluster with empty update",
+			newTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{},
+				},
+			},
+			oldTemplate: &infrav1.YandexCluster{
+				Spec: infrav1.YandexClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(_ *testing.T) {
+			warn, err := test.newTemplate.ValidateUpdate(test.oldTemplate)
+			if test.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(warn).To(BeNil())
+		})
+	}
+}

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,39 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: issuer
+    app.kubernetes.io/instance: selfsigned-issuer
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: cluster-api-provider-yandex
+    app.kubernetes.io/part-of: cluster-api-provider-yandex
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: cluster-api-provider-yandex
+    app.kubernetes.io/part-of: cluster-api-provider-yandex
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,14 +12,14 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_yandexclusters.yaml
+- patches/webhook_in_yandexclusters.yaml
 #- patches/webhook_in_yandexmachines.yaml
 #- patches/webhook_in_yandexmachinetemplates.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_yandexclusters.yaml
+- patches/cainjection_in_yandexclusters.yaml
 #- patches/cainjection_in_yandexmachines.yaml
 #- patches/cainjection_in_yandexmachinetemplates.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,5 +42,40 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../webhook
+- ../certmanager
+
 patches:
 - path: manager_auth_proxy_patch.yaml
+- path: webhookcainjection_patch.yaml
+- path: manager_webhook_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,29 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: MutatingWebhookConfiguration
+# metadata:
+#   labels:
+#     app.kubernetes.io/name: mutatingwebhookconfiguration
+#     app.kubernetes.io/instance: mutating-webhook-configuration
+#     app.kubernetes.io/component: webhook
+#     app.kubernetes.io/created-by: cluster-api-provider-yandex
+#     app.kubernetes.io/part-of: cluster-api-provider-yandex
+#     app.kubernetes.io/managed-by: kustomize
+#   name: mutating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: cluster-api-provider-yandex
+    app.kubernetes.io/part-of: cluster-api-provider-yandex
+    app.kubernetes.io/managed-by: kustomize
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,6 +10,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-yandexcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.yandexclusters.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - yandexclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-yandexmachine
   failurePolicy: Fail
   name: validation.yandexmachines.infrastructure.cluster.x-k8s.io

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: cluster-api-provider-yandex
+    app.kubernetes.io/part-of: cluster-api-provider-yandex
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/main.go
+++ b/main.go
@@ -143,6 +143,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&infrav1.YandexCluster{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "YandexCluster")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds cluster webhook, which provide validation of YandexCluster resource.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
