### PR TITLE
:bug: add support for YandexMachine reconciliation of deleted vm

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -944,7 +944,7 @@ func (c *ClusterTestEnv) setNewYandexMachineReconcileMocks(address string) {
 	)
 }
 
-// setNewYandexMachineWithReconcileMocks mocks the YandexClient API calls on YandexMachine reconciliation with API errors.
+// setNewYandexMachineErrorReconcileMocks mocks the YandexClient API calls on YandexMachine reconciliation with API errors.
 func (c *ClusterTestEnv) setNewYandexMachineErrorReconcileMocks() {
 	const mockID string = "123"
 
@@ -978,6 +978,31 @@ func (c *ClusterTestEnv) setNewYandexMachineErrorReconcileMocks() {
 					map[string]interface{}{"id": id},
 					[]interface{}{instance, nil})
 				return instance, nil
+			}),
+	)
+}
+
+// setYandexMachineNotFoundReconcileMocks mocks the YandexClient API calls on YandexMachine reconciliation with NotFound API error.
+func (c *ClusterTestEnv) setYandexMachineNotFoundReconcileMocks() {
+	const mockID string = "123"
+	notFoundError := status.Error(codes.NotFound, "instance not found")
+
+	gomock.InOrder(
+		e.mockClient.EXPECT().ComputeCreate(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *compute.CreateInstanceRequest) (string, error) {
+				logFunctionCalls(
+					"ComputeCreate",
+					map[string]interface{}{"request": req},
+					[]interface{}{mockID, nil})
+				return mockID, nil
+			}),
+		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
+				logFunctionCalls(
+					"ComputeGet",
+					map[string]interface{}{"id": id},
+					[]interface{}{"", notFoundError})
+				return nil, notFoundError
 			}),
 	)
 }
@@ -1029,11 +1054,13 @@ func (c *ClusterTestEnv) setNewCPYandexMachineReconcileMocks(address, targetGrou
 			}),
 		e.mockClient.EXPECT().ALBAddTarget(gomock.Any(), &alb.AddTargetsRequest{
 			TargetGroupId: mockID,
-			Targets: []*alb.Target{{
-				SubnetId: "subnetid",
-				AddressType: &alb.Target_IpAddress{
-					IpAddress: address,
-				}},
+			Targets: []*alb.Target{
+				{
+					SubnetId: "subnetid",
+					AddressType: &alb.Target_IpAddress{
+						IpAddress: address,
+					},
+				},
 			},
 		}).DoAndReturn(func(_ context.Context, req *alb.AddTargetsRequest) (*operation.Operation, error) {
 			logFunctionCalls(
@@ -1092,11 +1119,13 @@ func (c *ClusterTestEnv) setNewCPYandexMachineErrorReconcileMocks(address, targe
 			}),
 		e.mockClient.EXPECT().ALBAddTarget(gomock.Any(), &alb.AddTargetsRequest{
 			TargetGroupId: mockID,
-			Targets: []*alb.Target{{
-				SubnetId: "subnetid",
-				AddressType: &alb.Target_IpAddress{
-					IpAddress: address,
-				}},
+			Targets: []*alb.Target{
+				{
+					SubnetId: "subnetid",
+					AddressType: &alb.Target_IpAddress{
+						IpAddress: address,
+					},
+				},
 			},
 		}).DoAndReturn(func(_ context.Context, req *alb.AddTargetsRequest) (*operation.Operation, error) {
 			err := fmt.Errorf("alb target group add error")
@@ -1140,11 +1169,13 @@ func (c *ClusterTestEnv) setNewCPYandexMachineErrorReconcileMocks(address, targe
 			}),
 		e.mockClient.EXPECT().ALBAddTarget(gomock.Any(), &alb.AddTargetsRequest{
 			TargetGroupId: mockID,
-			Targets: []*alb.Target{{
-				SubnetId: "subnetid",
-				AddressType: &alb.Target_IpAddress{
-					IpAddress: address,
-				}},
+			Targets: []*alb.Target{
+				{
+					SubnetId: "subnetid",
+					AddressType: &alb.Target_IpAddress{
+						IpAddress: address,
+					},
+				},
 			},
 		}).DoAndReturn(func(_ context.Context, req *alb.AddTargetsRequest) (*operation.Operation, error) {
 			logFunctionCalls(
@@ -1302,11 +1333,13 @@ func (c *ClusterTestEnv) setCPYandexMachineDeleteMocks(mockID, mockAddress strin
 			}),
 		e.mockClient.EXPECT().ALBRemoveTarget(gomock.Any(), &alb.RemoveTargetsRequest{
 			TargetGroupId: mockID,
-			Targets: []*alb.Target{{
-				SubnetId: "subnetid",
-				AddressType: &alb.Target_IpAddress{
-					IpAddress: mockAddress,
-				}},
+			Targets: []*alb.Target{
+				{
+					SubnetId: "subnetid",
+					AddressType: &alb.Target_IpAddress{
+						IpAddress: mockAddress,
+					},
+				},
 			},
 		}).DoAndReturn(func(_ context.Context, req *alb.RemoveTargetsRequest) (*operation.Operation, error) {
 			logFunctionCalls(
@@ -1365,11 +1398,13 @@ func (c *ClusterTestEnv) setCPYandexMachineDeleteMocks(mockID, mockAddress strin
 			}),
 		e.mockClient.EXPECT().ALBRemoveTarget(gomock.Any(), &alb.RemoveTargetsRequest{
 			TargetGroupId: mockID,
-			Targets: []*alb.Target{{
-				SubnetId: "subnetid",
-				AddressType: &alb.Target_IpAddress{
-					IpAddress: mockAddress,
-				}},
+			Targets: []*alb.Target{
+				{
+					SubnetId: "subnetid",
+					AddressType: &alb.Target_IpAddress{
+						IpAddress: mockAddress,
+					},
+				},
 			},
 		}).DoAndReturn(func(_ context.Context, req *alb.RemoveTargetsRequest) (*operation.Operation, error) {
 			logFunctionCalls(


### PR DESCRIPTION
**What this PR does / why we need it**:
PR fix a bug when we delete a cloud instance in Yandex Cloud during the time of creating YandexMachine. Controller marks YandexMachine as deleted, set failureReason/failureMessage. After that CAPI controller switch Machine's phase: Failed and set failureReason/failureMessage.
If you want to delete Failed Machines and create new ones using CAPI, you have to configure MachineHealthCheck.

**Which issue(s) this PR fixes** (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
fixes https://github.com/yandex-cloud/cluster-api-provider-yandex/issues/38
