### PR TITLE
🐛Fix handle nil reference for TargetGroup

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1072,50 +1072,6 @@ func (c *ClusterTestEnv) setNewCPYandexMachineReconcileMocks(address, targetGrou
 	)
 }
 
-// setNewWithoutTargetGroupCPYandexMachineReconcileMocks mocks the YandexClient API calls on YandexMachine with controlplane role reconciliation without having Target Group.
-func (c *ClusterTestEnv) setNewWithoutTargetGroupCPYandexMachineReconcileMocks(address string) {
-	const mockID string = "123"
-
-	gomock.InOrder(
-		e.mockClient.EXPECT().ComputeCreate(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, req *compute.CreateInstanceRequest) (string, error) {
-				logFunctionCalls(
-					"ComputeCreate",
-					map[string]interface{}{"request": req},
-					[]interface{}{mockID, nil})
-				return mockID, nil
-			}),
-		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
-			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
-				instance := &compute.Instance{
-					Name:   c.machineName,
-					Id:     mockID,
-					Status: compute.Instance_RUNNING,
-					NetworkInterfaces: []*compute.NetworkInterface{
-						{
-							PrimaryV4Address: &compute.PrimaryAddress{
-								Address: address,
-							},
-						},
-					},
-				}
-				logFunctionCalls(
-					"ComputeGet",
-					map[string]interface{}{"id": id},
-					[]interface{}{instance, nil})
-				return instance, nil
-			}),
-		e.mockClient.EXPECT().ALBTargetGroupGetByName(gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, name, zone string) (*alb.TargetGroup, error) {
-				logFunctionCalls(
-					"ALBTargetGroupGetByName",
-					map[string]interface{}{"name": name, "zone": zone},
-					[]interface{}{nil, nil})
-				return nil, nil
-			}),
-	)
-}
-
 // setNewCPYandexMachineErrorReconcileMock mocks the YandexClient API calls on controlplane role reconciliation with API error.
 func (c *ClusterTestEnv) setNewCPYandexMachineErrorReconcileMocks(address, targetGroup string) {
 	const mockID string = "123"
@@ -1457,5 +1413,80 @@ func (c *ClusterTestEnv) setCPYandexMachineDeleteMocks(mockID, mockAddress strin
 				[]interface{}{&operation.Operation{}, nil})
 			return &operation.Operation{}, nil
 		}),
+	)
+}
+
+// setCPYandexMachineWithoutTargetGroupDeleteMocks mocks the YandexClient API calls on control plane YandexMachine without target group delete.
+func (c *ClusterTestEnv) setCPYandexMachineWithoutTargetGroupDeleteMocks(mockID, mockAddress string) {
+	notFoundError := status.Error(codes.NotFound, "instance not found")
+
+	gomock.InOrder(
+		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
+				instance := &compute.Instance{
+					Name:   c.machineName,
+					Id:     mockID,
+					Status: compute.Instance_RUNNING,
+					NetworkInterfaces: []*compute.NetworkInterface{
+						{
+							PrimaryV4Address: &compute.PrimaryAddress{
+								Address: mockAddress,
+							},
+						},
+					},
+				}
+				logFunctionCalls(
+					"ComputeGet",
+					map[string]interface{}{"id": id},
+					[]interface{}{instance, nil})
+				return instance, nil
+			}),
+		e.mockClient.EXPECT().
+			ALBTargetGroupGetByName(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, name, zone string) (*alb.TargetGroup, error) {
+				logFunctionCalls(
+					"ALBTargetGroupGetByName",
+					map[string]interface{}{"name": name, "zone": zone},
+					[]interface{}{nil, nil})
+				return nil, nil
+			}),
+		e.mockClient.EXPECT().ComputeDelete(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) error {
+				logFunctionCalls(
+					"ComputeDelete",
+					map[string]interface{}{"id": id},
+					[]interface{}{nil})
+				return nil
+			}),
+		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
+				instance := &compute.Instance{
+					Name:   c.machineName,
+					Id:     mockID,
+					Status: compute.Instance_DELETING,
+				}
+				logFunctionCalls(
+					"ComputeGet",
+					map[string]interface{}{"id": id},
+					[]interface{}{instance, nil})
+				return instance, nil
+			}),
+		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
+				logFunctionCalls(
+					"ComputeGet",
+					map[string]interface{}{"id": id},
+					[]interface{}{nil, notFoundError})
+				return nil, notFoundError
+			}),
+		e.mockClient.EXPECT().
+			ALBTargetGroupGetByName(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, name, zone string) (*alb.TargetGroup, error) {
+				logFunctionCalls(
+					"ALBTargetGroupGetByName",
+					map[string]interface{}{"name": name, "zone": zone},
+					[]interface{}{nil, nil})
+				return nil, nil
+			}),
 	)
 }

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1072,6 +1072,50 @@ func (c *ClusterTestEnv) setNewCPYandexMachineReconcileMocks(address, targetGrou
 	)
 }
 
+// setNewCPYandexMachineWithoutTargetGroupErrorReconcileMocks mocks the YandexClient API calls on YandexMachine without TargetGroup with controlplane role reconciliation.
+func (c *ClusterTestEnv) setNewCPYandexMachineWithoutTargetGroupErrorReconcileMocks(address string) {
+	const mockID string = "123"
+
+	gomock.InOrder(
+		e.mockClient.EXPECT().ComputeCreate(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *compute.CreateInstanceRequest) (string, error) {
+				logFunctionCalls(
+					"ComputeCreate",
+					map[string]interface{}{"request": req},
+					[]interface{}{mockID, nil})
+				return mockID, nil
+			}),
+		e.mockClient.EXPECT().ComputeGet(gomock.Any(), mockID).
+			DoAndReturn(func(_ context.Context, id string) (*compute.Instance, error) {
+				instance := &compute.Instance{
+					Name:   c.machineName,
+					Id:     mockID,
+					Status: compute.Instance_RUNNING,
+					NetworkInterfaces: []*compute.NetworkInterface{
+						{
+							PrimaryV4Address: &compute.PrimaryAddress{
+								Address: address,
+							},
+						},
+					},
+				}
+				logFunctionCalls(
+					"ComputeGet",
+					map[string]interface{}{"id": id},
+					[]interface{}{instance, nil})
+				return instance, nil
+			}),
+		e.mockClient.EXPECT().ALBTargetGroupGetByName(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, name, zone string) (*alb.TargetGroup, error) {
+				logFunctionCalls(
+					"ALBTargetGroupGetByName",
+					map[string]interface{}{"name": name, "zone": zone},
+					[]interface{}{nil, nil})
+				return nil, nil
+			}),
+	)
+}
+
 // setNewCPYandexMachineErrorReconcileMock mocks the YandexClient API calls on controlplane role reconciliation with API error.
 func (c *ClusterTestEnv) setNewCPYandexMachineErrorReconcileMocks(address, targetGroup string) {
 	const mockID string = "123"

--- a/internal/pkg/cloud/services/loadbalancers/alb.go
+++ b/internal/pkg/cloud/services/loadbalancers/alb.go
@@ -308,6 +308,10 @@ func (s *Service) addTargetALB(ctx context.Context, ipAddress, subnetID string) 
 		return err
 	}
 
+	if tg == nil {
+		return nil
+	}
+
 	if s.isAddressRegisteredALB(ipAddress, subnetID, tg) {
 		return nil
 	}

--- a/internal/pkg/cloud/services/loadbalancers/alb.go
+++ b/internal/pkg/cloud/services/loadbalancers/alb.go
@@ -308,10 +308,6 @@ func (s *Service) addTargetALB(ctx context.Context, ipAddress, subnetID string) 
 		return err
 	}
 
-	if tg == nil {
-		return nil
-	}
-
 	if s.isAddressRegisteredALB(ipAddress, subnetID, tg) {
 		return nil
 	}
@@ -346,6 +342,10 @@ func (s *Service) removeTargetALB(ctx context.Context, ipAddress, subnetID strin
 
 // isAddressRegisteredALB checks that the instance address is already registered to the ALB target group.
 func (s *Service) isAddressRegisteredALB(addr, subnetID string, tg *alb.TargetGroup) bool {
+	if tg == nil {
+		return false
+	}
+
 	for _, target := range tg.Targets {
 		ipAddress := &alb.Target_IpAddress{IpAddress: addr}
 		if reflect.DeepEqual(target.AddressType, ipAddress) && target.SubnetId == subnetID {

--- a/internal/pkg/cloud/services/loadbalancers/alb.go
+++ b/internal/pkg/cloud/services/loadbalancers/alb.go
@@ -308,6 +308,10 @@ func (s *Service) addTargetALB(ctx context.Context, ipAddress, subnetID string) 
 		return err
 	}
 
+	if tg == nil {
+		return nil
+	}
+
 	if s.isAddressRegisteredALB(ipAddress, subnetID, tg) {
 		return nil
 	}
@@ -331,6 +335,10 @@ func (s *Service) removeTargetALB(ctx context.Context, ipAddress, subnetID strin
 		return err
 	}
 
+	if tg == nil {
+		return nil
+	}
+
 	if !s.isAddressRegisteredALB(ipAddress, subnetID, tg) {
 		return nil
 	}
@@ -342,10 +350,6 @@ func (s *Service) removeTargetALB(ctx context.Context, ipAddress, subnetID strin
 
 // isAddressRegisteredALB checks that the instance address is already registered to the ALB target group.
 func (s *Service) isAddressRegisteredALB(addr, subnetID string, tg *alb.TargetGroup) bool {
-	if tg == nil {
-		return false
-	}
-
 	for _, target := range tg.Targets {
 		ipAddress := &alb.Target_IpAddress{IpAddress: addr}
 		if reflect.DeepEqual(target.AddressType, ipAddress) && target.SubnetId == subnetID {

--- a/internal/pkg/cloud/services/loadbalancers/alb.go
+++ b/internal/pkg/cloud/services/loadbalancers/alb.go
@@ -309,7 +309,7 @@ func (s *Service) addTargetALB(ctx context.Context, ipAddress, subnetID string) 
 	}
 
 	if tg == nil {
-		return nil
+		return fmt.Errorf("target group with name %s not found", builder.GetName())
 	}
 
 	if s.isAddressRegisteredALB(ipAddress, subnetID, tg) {
@@ -335,6 +335,8 @@ func (s *Service) removeTargetALB(ctx context.Context, ipAddress, subnetID strin
 		return err
 	}
 
+	// If TargetGroup is nil, it means the user deleted it manually.
+	// In this case, we take no action and consider it a normal scenario.
 	if tg == nil {
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a nil check for TargetGroup in the addTargetALB method to prevent a potential nil pointer exception (NPE).

**Which issue(s) this PR fixes**:
Fixes #39 
